### PR TITLE
Redis Sentinel Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,26 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        operating-system: [ubuntu-latest]
+        operating-system: ['ubuntu-20.04']
         python-version: ['3.7', '3.8', '3.9']
     runs-on: ${{ matrix.operating-system }}
-    services:
-      redis:
-        image: redis:6.0.9-alpine3.12
-        ports:
-          - 6379:6379
-        options: --entrypoint redis-server
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 1
+
+      - name: Install redis-server
+        run: |
+          sudo apt-get install curl
+          sudo sh -c 'echo "deb http://ppa.launchpad.net/redislabs/redis/ubuntu focal main" > /etc/apt/sources.list.d/redislabs-ubuntu-redis.list'
+          curl -sL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xCC59E6B43FA6E3CA' | sudo apt-key add
+          sudo apt update
+          # Prevent daemons from being started. See: https://serverfault.com/a/873827
+          sudo sh -c 'echo exit 101 > /usr/sbin/policy-rc.d'
+          sudo chmod +x /usr/sbin/policy-rc.d
+          sudo apt-get install -yf redis
+          sudo rm -f /usr/sbin/policy-rc.d
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2.1.4
@@ -48,7 +54,7 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
         run: |
-          python -m pytest --redis-url redis://$REDIS_HOST:$REDIS_PORT --cov-report=term tests/
+          python -m pytest --local-redis --log-cli-level=DEBUG --cov-report=term tests/
 
       - name: Flake8
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Install trio_redis and test requirements
         run: |
-          python -m pip install --use-feature=2020-resolver --user -e .
-          python -m pip install --use-feature=2020-resolver --user -r tests/requirements.txt
+          python -m pip install wheel
+          python -m pip install --user -e .
+          python -m pip install --user -r tests/requirements.txt
 
       - name: Test trio_redis
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Install trio_redis and test requirements
         run: |
-          python -m pip install wheel
-          python -m pip install --user -e .
+          python -m pip install 'wheel>=0.36.2'
           python -m pip install --user -r tests/requirements.txt
+          python -m pip install --user -e .
 
       - name: Test trio_redis
         env:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Get db from Redis URL path part in _redis._parse_url().
+- Use a local Redis server for testing. Tests are much faster.
+- Add RedisSentinel, a client that gets the address of the Redis server
+  from a list Sentinel servers (on connect and on reconnect after a
+  fail-over).
+
 ## 0.2.3
 
 - Replace Poetry with Setuptools.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 - Add RedisSentinel, a client that gets the address of the Redis server
   from a list Sentinel servers (on connect and on reconnect after a
   fail-over).
+- RedisPool now accepts a factory function to allow pooling of any
+  Redis-like client (e.g. Redis and RedisSentinel).
 
 ## 0.2.3
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='trio_redis',
-    version='0.2.3',
+    version='0.3.0',
     author='Omnidots B.V.',
     author_email='support@omnidots.com',
     description='A Redis client for Trio.',
@@ -14,6 +14,7 @@ setuptools.setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=['trio_redis'],
     python_requires='>=3.7',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from trio_redis.testing_utils import (  # noqa: F401
     pytest_addoption,
     redis,
     redis_pool,
-    redis_url,
+    redis_sentinel_cluster,
     redis_server,
+    redis_url,
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,13 @@
-coverage
-flake8
-flake8-comprehensions
-flake8-fixme
-flake8-quotes
-pytest
-pytest-cov
-pytest-trio
+# trio_redis requirements.
+trio>=0.17.0
+hiredis>=1.1.0
+
+# Test requirements.
+coverage>=5.3.1
+flake8>=3.8.4
+flake8-comprehensions>=3.3.1
+flake8-fixme>=1.1.1
+flake8-quotes>=3.2.0
+pytest>=6.2.1
+pytest-cov>=2.10.1
+pytest-trio>=0.7.0

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,0 +1,36 @@
+from trio_redis import RedisSentinel
+from trio_redis._redis import Sentinel
+
+
+async def test_simple(redis_sentinel_cluster):
+    client = RedisSentinel.from_url(
+        'test_cluster',
+        redis_sentinel_cluster.sentinels(),
+    )
+    await client.connect()
+    await client.set('x', 1)
+    await client.aclose()
+
+
+async def test_get_master_addr_by_name(redis_sentinel_cluster):
+    client = Sentinel.from_url(redis_sentinel_cluster.sentinels())
+    await client.connect()
+    assert (await client.get_master_addr_by_name('test_cluster')) == ('127.0.0.1', 6379)
+    await client.aclose()
+
+
+async def test_failover(redis_sentinel_cluster):
+    client = RedisSentinel.from_url(
+        'test_cluster',
+        redis_sentinel_cluster.sentinels(),
+    )
+    await client.connect()
+    await client.set('x', 1)
+
+    # Force fail=over by killing the current master.
+    await redis_sentinel_cluster.kill_master()
+
+    # This should block until the new master is available.
+    assert await client.get('x') == b'1'
+
+    await client.aclose()

--- a/trio_redis/__init__.py
+++ b/trio_redis/__init__.py
@@ -1,1 +1,1 @@
-from ._redis import Redis, RedisPool  # noqa: F401
+from ._redis import Redis, RedisPool, RedisSentinel  # noqa: F401

--- a/trio_redis/_connection.py
+++ b/trio_redis/_connection.py
@@ -22,6 +22,9 @@ class Connection:
 
         self._cleanup_timeout = 5.0
 
+    def __repr__(self):
+        return f'<{self.__class__.__name__}: {self.host}:{self.port}>'
+
     async def connect(self):
         if self._is_connected:
             raise BusyError('already connected')

--- a/trio_redis/_errors.py
+++ b/trio_redis/_errors.py
@@ -1,3 +1,7 @@
+class ConnectError(Exception):
+    pass
+
+
 class BusyError(Exception):
     pass
 
@@ -6,7 +10,20 @@ class ClosedError(Exception):
     pass
 
 
+def create_error_from_reply(obj):
+    msg = str(obj)
+
+    if msg.startswith('READONLY'):
+        cls = ReadOnlyError
+    else:
+        cls = ReplyError
+
+    return cls(str(obj))
+
+
 class ReplyError(Exception):
-    @classmethod
-    def from_error_reply(cls, reply):
-        return cls(str(reply))
+    pass
+
+
+class ReadOnlyError(ReplyError):
+    pass

--- a/trio_redis/_redis.py
+++ b/trio_redis/_redis.py
@@ -136,22 +136,26 @@ class RedisPool(_BaseRedis, *_commands):
     def redis(cls, host=None, port=None, db=None, url=None, **pool_kwargs):
         if ((host or port) and url) or not ((host or port) or url):
             raise ValueError('either host and port OR url must be given')
+
         def redis_factory():
             if host or port:
                 return Redis(host, port, db)
             else:
                 return Redis.from_url(url)
+
         return cls(redis_factory, **pool_kwargs)
 
     @classmethod
     def redis_sentinel(cls, master_name, addresses=None, urls=None, **pool_kwargs):
         if (addresses and urls) or not (addresses or urls):
             raise ValueError('either addresses OR urls must be given')
+
         def redis_sentinel_factory():
             if addresses:
                 return RedisSentinel(master_name, addresses)
             else:
                 return RedisSentinel.from_url(master_name, urls)
+
         return cls(redis_sentinel_factory, **pool_kwargs)
 
     async def connect(self):

--- a/trio_redis/_redis.py
+++ b/trio_redis/_redis.py
@@ -96,7 +96,7 @@ class _BareRedis(_BaseRedis):
 
     def _parse_reply(self, reply, parse_callback):
         if isinstance(reply, hiredis.ReplyError):
-            reply = _errors.create_error_from_reply(reply)
+            raise _errors.create_error_from_reply(reply)
         else:
             reply = parse_callback(reply)
         return reply

--- a/trio_redis/_redis.py
+++ b/trio_redis/_redis.py
@@ -134,7 +134,7 @@ class RedisPool(_BaseRedis, *_commands):
 
     @classmethod
     def redis(cls, host=None, port=None, db=None, url=None, **pool_kwargs):
-        if ((host or port) and url) or not ((host or port) or url):
+        if bool(host or port) == bool(url):
             raise ValueError('either host and port OR url must be given')
 
         def redis_factory():
@@ -147,7 +147,7 @@ class RedisPool(_BaseRedis, *_commands):
 
     @classmethod
     def redis_sentinel(cls, master_name, addresses=None, urls=None, **pool_kwargs):
-        if (addresses and urls) or not (addresses or urls):
+        if bool(addresses) == bool(urls):
             raise ValueError('either addresses OR urls must be given')
 
         def redis_sentinel_factory():

--- a/trio_redis/testing_utils.py
+++ b/trio_redis/testing_utils.py
@@ -3,27 +3,23 @@ Testing utilities for trio_redis.
 """
 
 import logging
-import re
-import random
-import string
+import shutil
 import subprocess
+import tempfile
 from contextlib import asynccontextmanager
+from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
 import trio
 
-from ._redis import Redis, RedisPool, DEFAULT_HOST, DEFAULT_PORT
+from ._redis import Redis, RedisPool, Sentinel, DEFAULT_HOST, DEFAULT_PORT
 
 
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_REDIS_IMAGE = 'redis:6.0.9-alpine3.12'
 DEFAULT_REDIS_URL = 'redis://localhost'
-
-
-_RE_DOCKER_PORT_MAPPING = re.compile(b'\\d+/tcp -> .*?:(?P<host_port>\\d+)')
 
 
 def pytest_addoption(parser):
@@ -34,24 +30,31 @@ def pytest_addoption(parser):
         help='URL to Redis, e.g. redis://<hostname>[:<port>]',
     )
     parser.addoption(
-        '--docker-redis',
+        '--local-redis',
         action='store_true',
         default=False,
-        help='Start a Redis container.',
+        help='Start a Redis server.',
     )
 
 
-# NOTE: Trio fixtures must be function-scope. This makes the tests
-# slower when --docker-redis is given, because a Redis container is
-# started for every test.
 @pytest.fixture(scope='function')
 async def redis_server(request):
-    docker_redis = request.config.getoption('--docker-redis')
-    if docker_redis:
-        async with _new_redis_server() as docker_redis_url:
-            yield docker_redis_url
+    local_server = request.config.getoption('--local-redis')
+    if local_server:
+        async with _new_redis_server() as local_server_url:
+            yield local_server_url
     else:
         yield None
+
+
+@pytest.fixture(scope='function')
+async def redis_sentinel_cluster(request):
+    try:
+        m = RedisSentinelManager()
+        await m.start()
+        yield m
+    finally:
+        await m.stop()
 
 
 @pytest.fixture(scope='function')
@@ -102,80 +105,17 @@ async def _new_x(cls, url):
 
 @asynccontextmanager
 async def _new_redis_server():
-    container_name = _redis_container_name()
-    kwargs = {
-        'command': _redis_container_args(container_name),
-        'stdout': subprocess.PIPE,
-        'stderr': subprocess.PIPE,
-    }
+    tmp = Path(tempfile.mkdtemp())
+    conf = tmp / 'redis.conf'
+    conf.write_text('appendonly yes')
+    proc = RedisNodeProcess(tmp, DEFAULT_PORT)
 
-    async with await trio.open_process(**kwargs) as proc:
-        has_error = False
-
-        try:
-            while True:
-                if proc.poll() is not None:
-                    raise RuntimeError('Redis server exited')
-                stdout = await proc.stdout.receive_some()
-                if b'Ready to accept connections' in stdout:
-                    break
-            host_port = await _redis_container_port(container_name)
-            url = f'redis://localhost:{host_port}'
-            yield url
-        except Exception:
-            has_error = True
-            raise
-        finally:
-            if has_error:
-                logger.error('STDERR: ' + (await _drain_stream(proc.stderr)).decode('utf-8'))
-            proc.terminate()
-            await proc.wait()
-
-
-def _redis_container_name():
-    return f'pytest-redis-{_random_string()}'
-
-
-def _redis_container_args(container_name):
-    return [
-        'docker',
-        'run',
-        '-p', '6379',  # No host port means 'choose random port'.
-        '--name', container_name,
-        '--rm',
-        DEFAULT_REDIS_IMAGE,
-    ]
-
-
-async def _redis_container_port(container_name):
-    completed_proc = await trio.run_process(
-        command=['docker', 'port', container_name],
-        capture_stdout=True,
-        stderr=subprocess.STDOUT,
-    )
-    port_mapping = completed_proc.stdout
-    match = _RE_DOCKER_PORT_MAPPING.match(port_mapping)
-    port_mapping = match.groupdict()
-    if match is None:
-        raise ValueError(f'cannot get host port from {port_mapping!r}')
-    host_port = int(port_mapping['host_port'].decode('utf-8'))
-    return host_port
-
-
-def _random_string():
-    return ''.join(random.choices(string.ascii_lowercase, k=6))
-
-
-async def _drain_stream(stream):
-    buf = []
-
-    while True:
-        data = await stream.receive_some()
-        if not data:
-            break
-        buf.append(data)
-
-    return b''.join(buf)
+    try:
+        await proc.open()
+        yield f'redis://localhost:{DEFAULT_PORT}'
+    finally:
+        await proc.terminate()
+        shutil.rmtree(tmp)
 
 
 async def fail_if_not_between(after, before, coroutine):
@@ -243,3 +183,225 @@ class TCPProxy:
 
     class CloseClientConnection(Exception):
         pass
+
+
+class RedisSentinelManager:
+    MAX_SENTINEL_DISCOVERY_WAIT = 10.0
+
+    _SENTINEL_PORT = 26379
+    _REDIS_PORT = 6379
+    _MASTER_CONFIG = """\
+appendonly yes
+port {PORT}
+"""
+    _REPLICA_CONFIG = """\
+appendonly yes
+port {PORT}
+replicaof 127.0.0.1 {MASTER_PORT}
+"""
+    _SENTINEL_CONFIG = """\
+port {PORT}
+sentinel monitor test_cluster 127.0.0.1 {MASTER_PORT} {QUORUM}
+sentinel down-after-milliseconds test_cluster 5000
+sentinel failover-timeout test_cluster 60000
+sentinel parallel-syncs test_cluster 1
+"""
+
+    def __init__(self):
+        self.sentinel_count = 3
+        self.replica_count = 2
+        self.logger = get_class_logger(self.__class__)
+
+        self._tmp = None
+        self._sentinels = []
+        self._nodes = []
+
+    async def start(self):
+        self._tmp = Path(tempfile.mkdtemp())
+
+        config = self._create_config(self._REDIS_PORT, self._MASTER_CONFIG, {
+            'PORT': self._REDIS_PORT,
+        })
+        self._nodes.append(RedisNodeProcess(config.parent, self._REDIS_PORT))
+
+        for n in range(1, self.replica_count + 1):
+            port = self._REDIS_PORT + n
+            config = self._create_config(port, self._REPLICA_CONFIG, {
+                'PORT': port,
+                'MASTER_PORT': self._REDIS_PORT,
+            })
+            self._nodes.append(RedisNodeProcess(config.parent, port))
+
+        for n in range(self.sentinel_count):
+            port = self._SENTINEL_PORT + n
+            config = self._create_config(port, self._SENTINEL_CONFIG, {
+                'PORT': port,
+                'MASTER_PORT': self._REDIS_PORT,
+                'QUORUM': self.sentinel_count - 1,
+            })
+            self._sentinels.append(RedisSentinelProcess(config.parent, port))
+
+        for node in self._nodes:
+            await node.open()
+        for sentinel in self._sentinels:
+            await sentinel.open()
+
+        # Wait until sentinel has discovered the replicas.
+        # Otherwise automatic failover is not possible.
+        sc = await self._sentinel_client()
+        with trio.fail_after(self.MAX_SENTINEL_DISCOVERY_WAIT + 300.0):
+            while True:
+                actual_replicas = len(await sc.replicas('test_cluster'))
+                actual_sentinels = len(await sc.sentinels('test_cluster'))
+                expected_replicas = len(self._nodes) - 1
+                expected_sentinels = len(self._sentinels) - 1
+                if actual_replicas == expected_replicas \
+                        and actual_sentinels == expected_sentinels:
+                    # Give the sentinels some time to process stuff.
+                    await trio.sleep(1.0)
+                    break
+                # Don't spam sentinel.
+                await trio.sleep(0.1)
+
+    async def stop(self):
+        if not self._tmp:
+            return
+        for sentinel in self._sentinels:
+            await sentinel.terminate()
+        for node in self._nodes:
+            await node.terminate()
+        shutil.rmtree(self._tmp)
+
+    def _create_config(self, port, template, params):
+        base = (self._tmp / str(port))
+        base.mkdir()
+        config = base / 'redis.conf'
+        config.write_text(template.format(**params))
+        return config
+
+    async def kill_master(self):
+        # Lookup master address and process.
+        sc = await self._sentinel_client()
+        addr = await sc.get_master_addr_by_name('test_cluster')
+        proc = await self._lookup_node_by_port(addr[1])
+
+        # Kill server.
+        rc = Redis(*addr)
+        await rc.connect()
+        try:
+            await rc.execute([b'DEBUG', b'SEGFAULT'])
+        except rc.ClosedError:
+            # We're segfaulting the server. Errors can be ignored. :)
+            pass
+
+        await proc.terminate()
+        await sc.aclose()
+
+    async def _sentinel_client(self):
+        client = Sentinel.from_url(self.sentinels())
+        await client.connect()
+        return client
+
+    async def _lookup_node_by_port(self, port):
+        for node in self._nodes:
+            if node.port == port:
+                return node
+        raise ValueError(f'no process with port {port}')
+
+    def sentinels(self):
+        return [s.url for s in self._sentinels]
+
+
+class _RedisProcess:
+    MAX_STARTUP_WAIT = 5.0
+    MAX_SHUTDOWN_WAIT = 2.0
+    MAX_STDOUT_DRAIN_TIME = 2.0
+
+    def __init__(self, working_directory, port):
+        self._proc = None
+        self._kwargs = {
+            'command': self.command(),
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.STDOUT,
+            'cwd': str(working_directory),
+        }
+
+        self.host = '127.0.0.1'
+        self.port = port
+        self.addr = f'{self.host}:{self.port}'
+        self.url = f'redis://{self.addr}'
+        self.logger = get_class_logger(self.__class__, self.url)
+
+    async def open(self):
+        try:
+            self._proc = await trio.open_process(**self._kwargs)
+            with trio.fail_after(self.MAX_STARTUP_WAIT):
+                while True:
+                    if self._proc.returncode is not None:
+                        raise OSError(f'redis-server exited with {self._proc.returncode}')
+                    stdout = await self._proc.stdout.receive_some()
+                    self.logger.debug(stdout.decode('utf-8'))
+                    if self.ready_message() in stdout:
+                        break
+        except Exception:
+            await self.terminate()
+            raise
+
+    async def terminate(self):
+        if self._proc is None:
+            return
+
+        # Kill process.
+        with trio.move_on_after(self.MAX_SHUTDOWN_WAIT) as cancel_scope:
+            self._proc.terminate()
+            await self._proc.wait()
+        if cancel_scope.cancelled_caught:
+            self._proc.kill()
+            await self._proc.wait()
+
+        # Collect and log all output.
+        stdout = ''
+        with trio.move_on_after(self.MAX_STDOUT_DRAIN_TIME):
+            async for data in drain_stream(self._proc.stdout):
+                stdout += data
+        self.logger.debug(stdout)
+
+        self._proc = None
+
+    def command(self):
+        return [
+            'redis-server',
+            './redis.conf',
+            '--loglevel', 'verbose',
+        ]
+
+    def ready_message(self):
+        raise NotImplementedError
+
+
+class RedisNodeProcess(_RedisProcess):
+    def ready_message(self):
+        return b'* Ready to accept connections'
+
+
+class RedisSentinelProcess(_RedisProcess):
+    def command(self):
+        return super().command() + ['--sentinel']
+
+    def ready_message(self):
+        return b'* Running mode=sentinel, port='
+
+
+def get_class_logger(cls, suffix=''):
+    name = f'{cls.__module__}.{cls.__name__}'
+    if suffix:
+        name += f'({suffix})'
+    return logging.getLogger()
+
+
+async def drain_stream(stream):
+    while True:
+        data = (await stream.receive_some()).decode('utf-8')
+        if not data:
+            break
+        yield data

--- a/trio_redis/testing_utils.py
+++ b/trio_redis/testing_utils.py
@@ -81,19 +81,19 @@ async def redis_pool(redis_url):
 
 @asynccontextmanager
 async def new_redis(url):
-    async with _new_x(Redis, url) as client:
-        yield client
+    obj = Redis.from_url(url)
+    try:
+        await obj.connect()
+        yield obj
+    finally:
+        await obj.flushdb()
+        await obj.script_flush()
+        await obj.aclose()
 
 
 @asynccontextmanager
 async def new_redis_pool(url):
-    async with _new_x(RedisPool, url) as pool:
-        yield pool
-
-
-@asynccontextmanager
-async def _new_x(cls, url):
-    obj = cls.from_url(url)
+    obj = RedisPool.redis(url=url)
     try:
         await obj.connect()
         yield obj


### PR DESCRIPTION
Changes:

- Get db from Redis URL path part in _redis._parse_url().
- Use a local Redis server for testing. Tests are much faster.
- Add RedisSentinel, a client that gets the address of the Redis server
  from a list Sentinel servers (on connect and on reconnect after a
  fail-over).
- RedisPool now accepts a factory function to allow pooling of any
  Redis-like client (e.g. Redis and RedisSentinel).
- Add test fixture that starts a complete sentinel cluster (e.g. for testing fail-overs in tests).